### PR TITLE
Accept multiple conditional abbreviations

### DIFF
--- a/test/config.yaml
+++ b/test/config.yaml
@@ -72,3 +72,10 @@ abbrevs:
   - abbr: cond2
     snippet: conditional abbrev
     if: '[[ $ZABRZE_TEST = 0 ]]'
+
+  - abbr: cond3
+    snippet: conditional abbrev
+    if: '[[ $ZABRZE_TEST = 0 ]]'
+
+  - abbr: cond3
+    snippet: conditional fallback

--- a/test/integration_test.zsh
+++ b/test/integration_test.zsh
@@ -71,6 +71,7 @@ try "yes | ./a.ts"  ""          "yes | deno run ./a.ts"         ""              
 try "yes | ./ab.ts" ""          "yes | deno run ./ab.ts"        ""              ""
 try "cond"          ""          "conditional abbrev"            ""              ""
 try "cond2"         ""          "cond2"                         ""              ""
+try "cond3"         ""          "conditional fallback"          ""              ""
 
 if [ "$result" -ne 0 ]; then
     echo "test failed!!" >/dev/stderr


### PR DESCRIPTION
```yaml
abbrevs:
  # used if trash is installed
  - abbr: rm
    snippet: trash
    if: (( ${+commands[trash]} ))

  # fallback
  - abbr: rm
    snippet: rm -r
```