### PR TITLE
Allow the current buffer to be referenced by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,28 +89,7 @@ abbrevs:
     abbr: chrome
     snippet: open -a 'Google Chrome'
     if: '[[ "$OSTYPE" =~ darwin ]]' # only available in macOS
-```
 
-### Suffix alias
-
-```yaml
-abbrevs:
-  - name: python3 *.py
-    abbr-pattern: \.py$
-    snippet: python3
-    action: prepend
-```
-
-```zsh
-$ ./a.py<CR>
-#  ↓ expanded and executed
-$ python3 ./a.py
-```
-
-### Abbreviation fallback
-
-```yaml
-abbrevs:
   # used if trash is installed
   - abbr: rm
     snippet: trash
@@ -119,6 +98,22 @@ abbrevs:
   # fallback
   - abbr: rm
     snippet: rm -r
+```
+
+### Suffix alias
+
+```yaml
+abbrevs:
+  - name: python3 *.py
+    abbr-pattern: \.py$
+    snippet: python3 ${current_abbr}
+    evaluate: true
+```
+
+```zsh
+$ ./a.py<CR>
+#  ↓ expanded and executed
+$ python3 ./a.py
 ```
 
 ## Installation

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -459,11 +459,16 @@ fn replacement_for(
             snippet_prefix: "",
             snippet_suffix: "",
         },
-        Action::Prepend => SnippetReplacement {
-            start_index: command_start_index,
-            end_index: command_start_index,
-            snippet_prefix: "",
-            snippet_suffix: " ",
-        },
+        Action::Prepend => {
+            eprintln!(
+                "zabrze: WARNING! `action: prepend` is deprecated and will be removed in v0.2.0\n    ref: https://github.com/Ryooooooga/zabrze/pull/9"
+            );
+            SnippetReplacement {
+                start_index: command_start_index,
+                end_index: command_start_index,
+                snippet_prefix: "",
+                snippet_suffix: " ",
+            }
+        }
     }
 }

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -50,7 +50,7 @@ abbrevs:
     snippet: "[ {} ]"
     action: replace-all
 
-  # prepend
+  # prepend (deprecated)
   - abbr-pattern: ^\.\.(/\.\.)*/?$
     snippet: cd
     action: prepend
@@ -61,21 +61,21 @@ abbrevs:
 
   # suffix aliases
   - abbr-pattern: \.ts$
-    snippet: deno run
-    action: prepend
+    snippet: deno run ${current_abbr}
+    evaluate: true
 
   # conditional
   - abbr: cond
     snippet: conditional abbrev
-    if: '[[ $ZABRZE_TEST = 1 ]]'
+    if: "[[ $ZABRZE_TEST = 1 ]]"
 
   - abbr: cond2
     snippet: conditional abbrev
-    if: '[[ $ZABRZE_TEST = 0 ]]'
+    if: "[[ $ZABRZE_TEST = 0 ]]"
 
   - abbr: cond3
     snippet: conditional abbrev
-    if: '[[ $ZABRZE_TEST = 0 ]]'
+    if: "[[ $ZABRZE_TEST = 0 ]]"
 
   - abbr: cond3
     snippet: conditional fallback


### PR DESCRIPTION
Add `$current_command` and `$current_abbr` environment variables so they can be referenced from snippet.

```yaml
# ~/.config/zabrze/config.yaml
abbrevs:
  - abbr-pattern: ^\.\d+$
    snippet: awk '{ print ${current_abbr/./$} }'
    evaluate: true
```

```sh
$ cat a.txt | .3<CR>
  ↓
$ cat a.txt | awk '{ print $3 }'
```

## Deprecation

`action: prepend` has been deprecated.

Rewrite your `config.yaml` as follows:

```yaml
abbrevs:
  - abbr-pattern: \.py$
    snippet: python3
    action: prepend
  # ↓
  - abbr-pattern: \.py$
    snippet: python3 ${current_abbr}
    evaluate: true

  - abbr: install
    snippet: sudo
    global: true
    context: ^apt\s
    action: prepend
  # ↓
  - abbr: install
    snippet: sudo ${current_command}
    evaluate: true
    global: true
    context: ^apt\s
    action: replace-all
```