### PR TITLE
Delete abbreviation "cm" for "git" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ $ eval "$(zabrze init --bind-keys)"
 then
 
 ```zsh
-$ g<SP>cm<SP>
+$ g<SP>
 #  ↓ expanded
-$ git commit -m
+$ git
 
 $ cat a.txt | .1<CR>
 #  ↓ expanded and executed


### PR DESCRIPTION
I deleted the abbreviation "cm" for "git" because it is not found in `abbrevs`.