### PR TITLE
rename `$current_command` and `$current_abbr` to `$command`/`$abbr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ abbrevs:
 abbrevs:
   - name: python3 *.py
     abbr-pattern: \.py$
-    snippet: python3 ${current_abbr}
+    snippet: python3 $abbr
     evaluate: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,12 @@ abbrevs:
     snippet: open -a 'Google Chrome'
     if: '[[ "$OSTYPE" =~ darwin ]]' # only available in macOS
 
-  # used if trash is installed
   - abbr: rm
     snippet: trash
-    if: (( ${+commands[trash]} ))
+    if: (( ${+commands[trash]} )) # available if trash is installed
 
-  # fallback
   - abbr: rm
-    snippet: rm -r
+    snippet: rm -r # fallback
 ```
 
 ### Suffix alias

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -40,11 +40,15 @@ pub fn run(args: &ExpandArgs) {
         return;
     }
 
-    let current_command = escape(Cow::from(result.command));
-    let current_abbr = escape(Cow::from(result.last_arg));
+    let command = escape(Cow::from(result.command));
+    let abbr = escape(Cow::from(result.last_arg));
 
-    print!(r#"local current_command={current_command};"#);
-    print!(r#"local current_abbr={current_abbr};"#);
+    print!(r#"local command={command};"#);
+    print!(r#"local abbr={abbr};"#);
+
+    // Deprecation: `$current_command` and `$current_abbr` is deprecated, use `$command` and `$abbr` instead.
+    print!(r#"local current_command={command};"#);
+    print!(r#"local current_abbr={abbr};"#);
 
     let mut has_if = false;
     for expansion in &result.expansions {

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -61,7 +61,7 @@ abbrevs:
 
   # suffix aliases
   - abbr-pattern: \.ts$
-    snippet: deno run ${current_abbr}
+    snippet: deno run $abbr
     evaluate: true
 
   # conditional


### PR DESCRIPTION
Rename `$current_command` and `$current_abbr` to `$command`/`$abbr`.

## Deprecation

`$current_command` and `$current_abbr` have been deprecated, use `$command`/`$abbr` instead.