### PR TITLE
Release 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "zabrze"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ansi_term",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zabrze"
-version = "0.1.9"
+version = "0.1.10"
 authors = ['Ryooooooga <eial5q265e5@gmail.com>']
 description = 'ZSH abbreviation exapansion plugin'
 license = 'MIT'


### PR DESCRIPTION
- #12

## Deprecation

`$current_command` and `$current_abbr` have been deprecated, use `$command`/`$abbr` instead.