### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,12 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,37 +56,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -193,26 +156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
 ]
 
 [[package]]
@@ -377,12 +320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,7 +355,6 @@ name = "zabrze"
 version = "0.1.10"
 dependencies = [
  "ansi_term",
- "dirs",
  "regex",
  "serde",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +361,7 @@ name = "zabrze"
 version = "0.1.10"
 dependencies = [
  "ansi_term",
+ "glob",
  "regex",
  "serde",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "zabrze"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "ansi_term",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = '2018'
 
 [dependencies]
 ansi_term = "0.12"
+glob = "0.3"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zabrze"
-version = "0.1.10"
+version = "0.2.0"
 authors = ['Ryooooooga <eial5q265e5@gmail.com>']
 description = 'ZSH abbreviation exapansion plugin'
 license = 'MIT'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = '2018'
 
 [dependencies]
 ansi_term = "0.12"
-dirs = "4.0"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/src/config/abbrev.rs
+++ b/src/config/abbrev.rs
@@ -16,8 +16,6 @@ pub enum Action {
     ReplaceLast,
     #[serde(rename = "replace-all")]
     ReplaceAll,
-    #[serde(rename = "prepend")]
-    Prepend,
 }
 
 impl Default for Action {
@@ -322,7 +320,7 @@ mod tests {
                     name: None,
                     trigger: Trigger::Regex(r"\.py$".to_string()),
                     snippet: "python3".to_string(),
-                    action: Action::Prepend,
+                    action: Action::ReplaceLast,
                     context: None,
                     condition: None,
                     global: false,

--- a/src/config/config_path.rs
+++ b/src/config/config_path.rs
@@ -23,9 +23,7 @@ impl ConfigPath for ConfigPathImpl {
 fn get_default_dir<C: ConfigPath>(c: &C) -> Option<String> {
     // Return $ZABRZE_CONFIG_HOME if defined
     if let Some(zabrze_config_home) = c.env(ZABRZE_CONFIG_HOME_ENV_KEY) {
-        return zabrze_config_home
-            .to_str()
-            .map(|config_home| format!("{config_home}"));
+        return zabrze_config_home.to_str().map(String::from);
     }
 
     // Get ${XDG_CONFIG_HOME:-$HOME/.config}

--- a/src/config/config_path.rs
+++ b/src/config/config_path.rs
@@ -4,13 +4,13 @@ use std::path::PathBuf;
 
 static ZABRZE_CONFIG_FILE_ENV_KEY: &str = "ZABRZE_CONFIG_FILE";
 static XDG_CONFIG_HOME_ENV_KEY: &str = "XDG_CONFIG_HOME";
+static HOME_ENV_KEY: &str = "HOME";
 
 static DEFAULT_CONFIG_DIR: &str = "zabrze";
 static DEFAULT_CONFIG_FILE: &str = "config.yaml";
 
 trait ConfigPath {
     fn env(&self, key: &str) -> Option<OsString>;
-    fn home(&self) -> Option<PathBuf>;
 }
 
 #[derive(Debug)]
@@ -19,9 +19,6 @@ struct ConfigPathImpl {}
 impl ConfigPath for ConfigPathImpl {
     fn env(&self, key: &str) -> Option<OsString> {
         env::var_os(key)
-    }
-    fn home(&self) -> Option<PathBuf> {
-        dirs::home_dir()
     }
 }
 
@@ -36,7 +33,7 @@ fn get_default_path<C: ConfigPath>(c: &C) -> Option<PathBuf> {
         if let Some(xdg_config_home) = c.env(XDG_CONFIG_HOME_ENV_KEY).map(PathBuf::from) {
             xdg_config_home
         } else {
-            let mut path = c.home()?;
+            let mut path = c.env(HOME_ENV_KEY).map(PathBuf::from)?;
             path.push(".config");
             path
         };
@@ -60,15 +57,11 @@ mod tests {
     #[derive(Debug)]
     struct DummyConfigPath {
         envs: HashMap<&'static str, &'static str>,
-        home: &'static str,
     }
 
     impl ConfigPath for DummyConfigPath {
         fn env(&self, key: &str) -> Option<OsString> {
             self.envs.get(key).map(OsString::from)
-        }
-        fn home(&self) -> Option<PathBuf> {
-            Some(PathBuf::from(self.home))
         }
     }
 
@@ -77,7 +70,6 @@ mod tests {
         struct Scenario {
             pub testname: &'static str,
             pub envs: HashMap<&'static str, &'static str>,
-            pub home: &'static str,
             pub expected: &'static str,
         }
 
@@ -87,24 +79,25 @@ mod tests {
                 envs: vec![
                     ("ZABRZE_CONFIG_FILE", "/home/user/.zabrze.yaml"),
                     ("XDG_CONFIG_HOME", "/home/user/.xdgConfig"),
+                    ("HOME", "/home/user"),
                 ]
                 .into_iter()
                 .collect(),
-                home: "/home/user/",
                 expected: "/home/user/.zabrze.yaml",
             },
             Scenario {
                 testname: "follow XDG_CONFIG_HOME",
-                envs: vec![("XDG_CONFIG_HOME", "/home/user/.xdgConfig")]
-                    .into_iter()
-                    .collect(),
-                home: "/home/user/",
+                envs: vec![
+                    ("XDG_CONFIG_HOME", "/home/user/.xdgConfig"),
+                    ("HOME", "/home/user"),
+                ]
+                .into_iter()
+                .collect(),
                 expected: "/home/user/.xdgConfig/zabrze/config.yaml",
             },
             Scenario {
                 testname: "use default path",
-                envs: HashMap::new(),
-                home: "/home/user/",
+                envs: vec![("HOME", "/home/user")].into_iter().collect(),
                 expected: "/home/user/.config/zabrze/config.yaml",
             },
         ];
@@ -112,7 +105,6 @@ mod tests {
         for s in &scenarios {
             let c = DummyConfigPath {
                 envs: s.envs.clone(),
-                home: s.home,
             };
 
             let expected = Some(PathBuf::from(s.expected));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,13 +2,13 @@ pub mod abbrev;
 pub mod config_path;
 
 pub use abbrev::{Abbrev, Action, Trigger};
-pub use config_path::default_config_path;
+pub use config_path::get_default_config_dir;
 
 use ansi_term::Color;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -39,11 +39,12 @@ impl Config {
     }
 
     pub fn load_or_exit() -> Self {
-        let path = &default_config_path().expect("could not determine config file path");
+        let config_dir = &get_default_config_dir().expect("could not determine config directory");
+        let mut path = PathBuf::from(config_dir);
+        path.push("config.yaml");
 
-        Self::load_from_file(path).unwrap_or_else(|err| {
-            let path = path.to_string_lossy();
-            let error_message = format!("failed to load config `{}': {}", path, err);
+        Self::load_from_file(&path).unwrap_or_else(|err| {
+            let error_message = format!("failed to load config `{}': {}", path.display(), err);
             let error_style = Color::Red.normal();
 
             eprintln!("{}", error_style.paint(error_message));

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -51,9 +51,9 @@ mod tests {
                 evaluate: true
 
               - name: ..
-                abbr: ^\.\.(/\.\.)*$
-                snippet: cd
-                action: prepend
+                abbr-pattern: ^\.\.(/\.\.)*$
+                snippet: cd $abbr
+                evaluate: true
             ",
         )
         .unwrap()
@@ -73,7 +73,7 @@ mod tests {
 c=commit
 null='>/dev/null'
 home='$HOME'
-^\.\.(/\.\.)*$=cd
+^\.\.(/\.\.)*$='cd $abbr'
 ";
 
         assert_eq!(output, expected);

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -50,14 +50,13 @@ abbrevs:
     snippet: "[ {} ]"
     action: replace-all
 
-  # prepend (deprecated)
+  # current_abbr
   - abbr-pattern: ^\.\.(/\.\.)*/?$
-    snippet: cd
-    action: prepend
+    snippet: cd $abbr
+    evaluate: true
 
   - abbr: placeholder
-    snippet: ab{}cd
-    action: prepend
+    snippet: ab{}cd placeholder
 
   # suffix aliases
   - abbr-pattern: \.ts$

--- a/test/config2.yml
+++ b/test/config2.yml
@@ -1,0 +1,4 @@
+abbrevs:
+  # simple
+  - abbr: "2"
+    snippet: otherfile

--- a/test/integration_test.zsh
+++ b/test/integration_test.zsh
@@ -72,6 +72,7 @@ try "yes | ./ab.ts" ""          "yes | deno run ./ab.ts"        ""              
 try "cond"          ""          "conditional abbrev"            ""              ""
 try "cond2"         ""          "cond2"                         ""              ""
 try "cond3"         ""          "conditional fallback"          ""              ""
+try "2"             ""          "otherfile"                     ""              ""
 
 if [ "$result" -ne 0 ]; then
     echo "test failed!!" >/dev/stderr

--- a/test/integration_test.zsh
+++ b/test/integration_test.zsh
@@ -40,7 +40,7 @@ try() {
     fi
 }
 
-export ZABRZE_CONFIG_FILE="${0:a:h}/config.yaml"
+export ZABRZE_CONFIG_HOME="${0:a:h}"
 export ZABRZE_TEST=1
 export EDITOR=vim
 


### PR DESCRIPTION
## Features

- support multiple config files: read all `.yaml`, `.yml` files under `~/.config/zabrze/`
- introduce `ZABRZE_CONFIG_HOME` env variable to change the config directory

## BREAKING CHANGES

- delete `action: prepend` (https://github.com/Ryooooooga/zabrze/pull/9)
- delete `ZABRZE_CONFIG_FILE` env variable