### PR TITLE
feat: implement capture groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ abbrevs:
 ```yaml
 abbrevs:
   - name: python3 *.py
+    abbr-pattern: ^(?<file>.+\.py)$
+    snippet: python3 $file
+    evaluate: true
+
+  # or
+  - name: python3 *.py
     abbr-pattern: \.py$
     snippet: python3 $abbr
     evaluate: true

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -4,10 +4,6 @@ abbrevs:
     abbr: g
     snippet: git
 
-  - name: ".1"
-    abbr: ".1"
-    snippet: awk '{ print $1 }'
-
   # global
   - name: ">null"
     abbr: ">null"
@@ -92,3 +88,9 @@ abbrevs:
 
   - abbr: cond3
     snippet: conditional fallback
+
+  # capture
+  - name: ".N"
+    abbr-pattern: ^\.(?<n>\d+)$
+    snippet: awk '{ print \$$n }'
+    evaluate: true

--- a/test/integration_test.zsh
+++ b/test/integration_test.zsh
@@ -51,7 +51,6 @@ try "g"             "add"       "git"                           "add"           
 try "g"             " add"      "git"                           " add"          ""
 try "echo g"        ""          "echo g"                        ""              ""
 try "echo a; g"     ""          "echo a; git"                   ""              ""
-try "cat a | .1"    ""          "cat a | awk '{ print \$1 }'"   ""              ""
 try "view"          "a.txt"     "vim -R"                        "a.txt"         ""
 try "echo ANSWER"   ""          "echo answer is 42"             ""              ""
 try "ANSWER"        ""          "answer is 42"                  ""              ""
@@ -75,6 +74,8 @@ try "cond"          ""          "conditional abbrev"            ""              
 try "cond2"         ""          "cond2"                         ""              ""
 try "cond3"         ""          "conditional fallback"          ""              ""
 try "2"             ""          "otherfile"                     ""              ""
+try "cat a | .1"    ""          "cat a | awk '{ print \$1 }'"   ""              ""
+try "cat a | .2"    ""          "cat a | awk '{ print \$2 }'"   ""              ""
 
 if [ "$result" -ne 0 ]; then
     echo "test failed!!" >/dev/stderr


### PR DESCRIPTION
```yaml
abbrevs:
  - abbr-pattern: ^.(?<n>\d+)$
    snippet: awk '{print \$$n}'
    evaluate: true
```

```
$ .2<CR>
  ↓
$ awk '{print $2}'
```